### PR TITLE
fix(stories): fixbug when no stories defined

### DIFF
--- a/components/sandbox-manager/sandbox-manager.js
+++ b/components/sandbox-manager/sandbox-manager.js
@@ -8,6 +8,8 @@ const AddonsApi = require('../../addons');
 
 const template = require('./sandbox-manager.html');
 
+const NO_STORIES_MSG = '<h1> No stories defined </h1>';
+
 require('../addons-panel/addons-panel');
 require('../stories-tree/stories-tree');
 require('../preview-frame/preview-frame');
@@ -28,8 +30,16 @@ const createElement = (name, attributes) => {
 class ManagerApp extends HTMLElement {
   connectedCallback() {
     this.innerHTML = template();
+    this.$leftPanel = this.querySelector('#left-panel');
+    this.$rightPanel = this.querySelector('#right-panel');
 
     const stories = getStories();
+
+    if (!Object.keys(stories).length) {
+      this.$rightPanel.innerHTML = NO_STORIES_MSG;
+      return;
+    }
+
     const firstStory = stories[Object.keys(stories)[0]];
     const addonPanels = AddonsApi.getPanels();
 
@@ -48,8 +58,6 @@ class ManagerApp extends HTMLElement {
     this.state = Object.assign({}, DEFAULT_PARAMS, this.router.getParams());
 
     // build panels
-    this.$leftPanel = this.querySelector('#left-panel');
-
     this.$leftPanel.appendChild(this.$storiesStree = createElement('stories-tree', {
       class: 'split content',
       state: stories,
@@ -59,8 +67,6 @@ class ManagerApp extends HTMLElement {
      *  correct order of components creation matters a lot here
      *  channel should be established before rendering plugins
      * */
-    this.$rightPanel = this.querySelector('#right-panel');
-
     this.$rightPanel.appendChild(this.$previewFrame = createElement('preview-frame', {
       class: 'split content',
       'url-base': this.router.options.base,

--- a/components/sandbox-manager/sandbox-manager.story.js
+++ b/components/sandbox-manager/sandbox-manager.story.js
@@ -1,11 +1,11 @@
 import { storiesOf } from '../../js/story';
 
 storiesOf('Sandbox manager (fractal)')
-  .add(`ok`, () => {
+  .add('ok', () => {
     require('./sandbox-manager');
     return `
       <b>ok, close it, it takes cpu</b>
       <sandbox-manager-application></sandbox-manager-application>
-    `
-  })
+    `;
+  });
 

--- a/demo/test-component/test-component.story.js
+++ b/demo/test-component/test-component.story.js
@@ -6,4 +6,4 @@ storiesOf('Test')
   .add('hello', () =>
     `<test-component>
       hello world
-    </test-component>`)
+    </test-component>`);


### PR DESCRIPTION
At the moment when no stories are defined a basic message is printed.
Another option could be to print an empty story with the message but can be misleading.

[issue #40](https://github.com/modulor-js/modulor-storybook/issues/40)