### PR TITLE
Fixes

### DIFF
--- a/components/sandbox-manager/sandbox-manager.js
+++ b/components/sandbox-manager/sandbox-manager.js
@@ -5,6 +5,7 @@ const { Router } = require('modulor/router');
 const { getStories } = require('../../js/story');
 const Channel = require('../../js/channel');
 const AddonsApi = require('../../addons');
+const config = require('../../js/config');
 
 const template = require('./sandbox-manager.html');
 
@@ -42,14 +43,13 @@ class ManagerApp extends HTMLElement {
 
     const firstStory = stories[Object.keys(stories)[0]];
     const addonPanels = AddonsApi.getPanels();
+    const defaultParams = config.getDefaultParams();
 
-    const DEFAULT_PARAMS = {
-      width: 80,
-      height: 75,
+    const DEFAULT_PARAMS = Object.assign({}, defaultParams, {
       story: firstStory.storyName,
       storyKind: Object.keys(firstStory.getStories())[0],
       addon: Object.keys(addonPanels)[0],
-    };
+    });
 
     this.router = new Router({
       base: window.location.pathname,

--- a/components/sandbox-manager/sandbox-manager.js
+++ b/components/sandbox-manager/sandbox-manager.js
@@ -120,7 +120,7 @@ class ManagerApp extends HTMLElement {
      *  here all routes changes will be observed
      *  only query parameters will be used
      * */
-    this.router.add('*', (path, query) => {
+    this.router.add('(.*)', (path, query) => {
       // set sizes
       const width = Number(query.width);
       const height = Number(query.height);

--- a/components/sandbox-manager/sandbox-manager.js
+++ b/components/sandbox-manager/sandbox-manager.js
@@ -5,7 +5,7 @@ const { Router } = require('modulor/router');
 const { getStories } = require('../../js/story');
 const Channel = require('../../js/channel');
 const AddonsApi = require('../../addons');
-const config = require('../../js/config');
+const { getDefaultParams } = require('../../js/config');
 
 const template = require('./sandbox-manager.html');
 
@@ -43,7 +43,7 @@ class ManagerApp extends HTMLElement {
 
     const firstStory = stories[Object.keys(stories)[0]];
     const addonPanels = AddonsApi.getPanels();
-    const defaultParams = config.getDefaultParams();
+    const defaultParams = getDefaultParams();
 
     const DEFAULT_PARAMS = Object.assign({}, defaultParams, {
       story: firstStory.storyName,

--- a/js/config.js
+++ b/js/config.js
@@ -1,11 +1,11 @@
-let config = {
+const config = {
   width: 80,
   height: 75,
 };
 
 module.exports = {
   getDefaultParams(){
-    return config;
+    return Object.assign({}, config);
   },
 
   setDefaultParams(params){

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,15 @@
+let config = {
+  width: 80,
+  height: 75,
+};
+
+module.exports = {
+  getDefaultParams(){
+    return config;
+  },
+
+  setDefaultParams(params){
+    return Object.assign(config, params);
+  }
+}
+


### PR DESCRIPTION
1) seems like `path-to-regexp` changed compiling or so. In my case routes in freshly-installed storybook `sandbox-manager` didn't handle parameters (router didn't resolve). this https://github.com/modulor-js/modulor-storybook/compare/fixes?expand=1#diff-2b6c10a00f0514c18d858be9e646d256R122 seems to fix it

2) In some cases it's nice to be able to set up default view params (preview height/width, disabling plugins/stories tree/filtering/etc). For example i'm currently making examples in `modulor-html` as stories and i'd like decrease default preview height.

proposed usage:
```js
//additional.js

import AddonsApi from 'modulor-storybook/addons';

AddonsApi.setDefaultViewParams({ height: 35 });
```

I put it in `AddonsApi`, though it might make sense to split it out as a separate module, like `config`. What do you guys think?